### PR TITLE
Change color variables names

### DIFF
--- a/static/less/global/footer.less
+++ b/static/less/global/footer.less
@@ -1,6 +1,6 @@
 footer {
-    background-color: @gg-blue;
-    color: @gg-grey;
+    background-color: @color-primary;
+    color: @color-background;
     padding: 30px 0;
     font-size: 0.9em;
     overflow: hidden;

--- a/static/less/global/header.less
+++ b/static/less/global/header.less
@@ -5,14 +5,14 @@ header.global, header.global.slim {
 
     padding: 0;
     border: 0 none;
-    background-color: @gg-blue;
+    background-color: @color-primary;
     margin-bottom: 0;
     transition: all .2s ease-in;
     box-shadow: none;
     border-radius: 0 !important;
 
     &:hover {
-        background-color: fadeout(@gg-blue, 20%);
+        background-color: fadeout(@color-primary, 20%);
     }
 
     > nav {
@@ -57,7 +57,7 @@ header.global, header.global.slim {
             margin: 0.9em 0 0 0;
             padding: 0;
             text-shadow: none;
-            color: @gg-grey;
+            color: @color-background;
 
             @media (max-width: @screen-sm-max) {
                 display: none;
@@ -74,7 +74,7 @@ header.global, header.global.slim {
             > li > a {
                 padding: 0;
                 font-weight: 500;
-                color: @gg-grey;
+                color: @color-background;
 
                 &:hover {
                     color: @white;
@@ -95,7 +95,7 @@ header.global, header.global.slim {
             margin: 0;
 
             > li > a.cta-login {
-                .ionisx-btn(@gg-blue, @white);
+                .ionisx-btn(@color-primary, @white);
             }
         }
 
@@ -103,7 +103,7 @@ header.global, header.global.slim {
             margin: 0;
 
             > li.primary > a {
-                .ionisx-btn(@gg-blue, @white);
+                .ionisx-btn(@color-primary, @white);
 
                 border-radius: 0;
                 border-top-left-radius: 4px;
@@ -115,7 +115,7 @@ header.global, header.global.slim {
                 }
 
                 &.dropdown.active {
-                    .ionisx-btn-hover(@gg-blue, @white);
+                    .ionisx-btn-hover(@color-primary, @white);
                 }
 
                 &.dropdown {
@@ -140,7 +140,7 @@ header.global, header.global.slim {
                 left: initial;
                 right: 0;
                 box-shadow: none;
-                border: 1px solid @gg-blue;
+                border: 1px solid @color-primary;
                 border-top: 0 none;
                 border-top-right-radius: 0;
                 background-color: @white;
@@ -159,7 +159,7 @@ header.global, header.global.slim {
                     }
 
                     &:hover {
-                        background-color: @gg-blue;
+                        background-color: @color-primary;
 
                         > a {
                             color: @white;
@@ -169,7 +169,7 @@ header.global, header.global.slim {
                     > a {
                         border: 0 none;
                         outline: none;
-                        color: @gg-blue;
+                        color: @color-primary;
                         padding: 0;
                         letter-spacing: normal;
 

--- a/static/less/global/main.less
+++ b/static/less/global/main.less
@@ -2,7 +2,7 @@ body,
 .view-login,
 .view-register,
 .view-passwordreset {
-    background-color: @gg-grey;
+    background-color: @color-background;
 
     @import 'header.less';
     @import 'modal.less';

--- a/static/less/global/modal.less
+++ b/static/less/global/modal.less
@@ -12,7 +12,7 @@
     }
 
     button.dismiss:not(.close-modal) {
-        .ionisx-btn(@white, @gg-alt-blue);
+        .ionisx-btn(@white, @color-secondary);
     }
 }
 
@@ -33,7 +33,7 @@
                 font-weight: @headings-font-weight;
                 text-transform: none;
                 text-align: center;
-                color: @gg-blue;
+                color: @color-primary;
             }
         }
 
@@ -71,7 +71,7 @@
             }
 
             button[type=submit] {
-                .ionisx-btn(@white, @gg-alt-blue);
+                .ionisx-btn(@white, @color-secondary);
             }
         }
     }

--- a/static/less/mixins/alert.less
+++ b/static/less/mixins/alert.less
@@ -39,8 +39,8 @@
 }
 
 .ionisx-alert-error {
-    background-color: @gg-pomegranate;
-    color: @gg-grey;
+    background-color: @color-error;
+    color: @color-background;
 
     h1, h2, h3, h4, h5 {
         color: @white;
@@ -58,7 +58,7 @@
 
 
 .ionisx-alert-warning {
-    background-color: @gg-orange;
+    background-color: @color-warning;
     color: @white;
 
     h1, h2, h3, h4, h5 {

--- a/static/less/mixins/button.less
+++ b/static/less/mixins/button.less
@@ -58,7 +58,7 @@
     }
 }
 
-.ionisx-btn-disabled(@fg-color: @gg-disabled-grey) {
+.ionisx-btn-disabled(@fg-color: @color-disabled) {
     .ionisx-btn(@fg-color, @white);
 
     cursor: default;

--- a/static/less/mixins/checkbox.less
+++ b/static/less/mixins/checkbox.less
@@ -23,7 +23,7 @@
         position: absolute;
         border: 1px solid @white;
         border-radius: @default-border-radius;
-        background-color: @gg-blue;
+        background-color: @color-primary;
         text-align: center;
         top: 2px;
         left: -1px;

--- a/static/less/mixins/input.less
+++ b/static/less/mixins/input.less
@@ -7,7 +7,7 @@
     color: inherit;
     box-shadow: none;
     border-radius: @default-border-radius;
-    border: 2px solid @gg-border-grey;
+    border: 2px solid @color-border;
     outline: none;
     padding: 0.6em 1em;
     transition: all .1s ease-in;
@@ -23,29 +23,29 @@
     }
 
     &.valid-input {
-        border-color: @gg-emerald;
+        border-color: @color-success;
 
         & + span:after {
-            color: @gg-emerald;
+            color: @color-success;
             content: '\f058';
         }
     }
 
     &.invalid-input {
-        border-color: @gg-pomegranate;
+        border-color: @color-error;
 
         & + span:after {
-            color: @gg-pomegranate;
+            color: @color-error;
             content: '\f057';
         }
     }
 
     &:focus, &:active {
-        border-color: @gg-blue;
+        border-color: @color-primary;
         box-shadow: none;
 
         & + span:after {
-            color: @gg-blue;
+            color: @color-primary;
         }
     }
 }

--- a/static/less/mixins/modal.less
+++ b/static/less/mixins/modal.less
@@ -22,7 +22,7 @@
     .inner-wrapper {
         overflow: visible;
         background: none;
-        background-color: @gg-grey;
+        background-color: @color-background;
         border: 1px solid fadeout(@black, 20%);
         border-radius: @default-border-radius;
         padding: 40px;
@@ -84,7 +84,7 @@
             input, textarea {
                 font: inherit;
                 border-radius: @default-border-radius;
-                border: 1px solid @gg-border-grey;
+                border: 1px solid @color-border;
                 outline: none;
             }
 
@@ -106,7 +106,7 @@
                 margin: 2em 0 0 0;
 
                 input[type=submit] {
-                    .ionisx-btn(@white, @gg-alt-blue);
+                    .ionisx-btn(@white, @color-secondary);
                 }
             }
         }

--- a/static/less/pages/course/about.less
+++ b/static/less/pages/course/about.less
@@ -4,7 +4,7 @@ section.course-info {
     header.course-profile {
         .square(auto);
 
-        background-color: @gg-blue;
+        background-color: @color-primary;
         border: 0 none;
         box-shadow: none;
         margin: 0;
@@ -18,7 +18,7 @@ section.course-info {
             background: none;
 
             .table {
-                background-color: @gg-grey;
+                background-color: @color-background;
                 display: block;
                 border-radius: @default-border-radius;
 
@@ -106,12 +106,12 @@ section.course-info {
                                 font-size: 42px;
                                 line-height: 44px;
                                 transition: all .1s ease-in;
-                                color: @gg-emerald;
+                                color: @color-success;
                             }
 
                             &:hover {
                                 span {
-                                    color: fadeout(@gg-emerald, 50%);
+                                    color: fadeout(@color-success, 50%);
                                 }
                             }
                         }
@@ -124,7 +124,7 @@ section.course-info {
                         float: none;
                         margin: 20px 0 0 0;
                         padding: 0 0 0 20px;
-                        border-left: 1px solid @gg-border-grey;
+                        border-left: 1px solid @color-border;
 
                         @media (max-width: @screen-sm-max) {
                             padding: 0;
@@ -142,7 +142,7 @@ section.course-info {
                             padding: 0;
 
                             strong, &.register, &.add-to-cart {
-                                .ionisx-btn(@white, @gg-alt-blue);
+                                .ionisx-btn(@white, @color-secondary);
                                 .size(49%, auto);
 
                                 @media (max-width: @screen-xs-max) {
@@ -170,7 +170,7 @@ section.course-info {
                             }
 
                             span.register.disabled.private {
-                                .ionisx-btn-disabled(@gg-pomegranate);
+                                .ionisx-btn-disabled(@color-error);
                                 .size(100%, auto);
                             }
                         }
@@ -193,13 +193,13 @@ section.course-info {
             table.course-summary {
                 .table-rounded(4px);
 
-                border: 1px solid @gg-border-grey;
+                border: 1px solid @color-border;
                 table-layout: fixed;
                 margin: 0 0 60px 0;
                 width: 100%;
 
                 thead {
-                    background-color: @gg-blue;
+                    background-color: @color-primary;
                     color: @white;
 
                     th {
@@ -280,7 +280,7 @@ section.course-info {
                                 font-family: 'FontAwesome';
                                 content: '\f054';
                                 margin-right: 0.5em;
-                                color: @gg-blue;
+                                color: @color-primary;
                             }
                         }
                     }

--- a/static/less/pages/course/book.less
+++ b/static/less/pages/course/book.less
@@ -13,7 +13,7 @@
         display: block;
         font: inherit;
         float: left;
-        border: 1px solid @gg-border-grey;
+        border: 1px solid @color-border;
         border-radius: @default-border-radius;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
@@ -34,7 +34,7 @@
             font-size: 0.9em;
 
             a, a:hover {
-                color: @gg-blue;
+                color: @color-primary;
             }
         }
     }
@@ -45,7 +45,7 @@
         .make-lg-column(9);
 
         display: block;
-        border: 1px solid @gg-border-grey;
+        border: 1px solid @color-border;
         border-left: 0 none;
         border-radius: @default-border-radius;
         border-top-left-radius: 0;

--- a/static/less/pages/course/courseware.less
+++ b/static/less/pages/course/courseware.less
@@ -16,11 +16,11 @@
         border: 0 none;
         transition: none;
         box-sizing: border-box;
-        border-right: 1px solid @gg-border-grey;
+        border-right: 1px solid @color-border;
 
         @media (max-width: @screen-sm-max) {
             border-right: none;
-            border-bottom: 2px solid @gg-border-grey;
+            border-bottom: 2px solid @color-border;
         }
 
         #accordion {
@@ -30,7 +30,7 @@
             .chapter {
                 border-radius: 0;
                 box-shadow: none;
-                border-bottom: 1px solid @gg-border-grey;
+                border-bottom: 1px solid @color-border;
                 padding: 0;
 
                 &:last-child {
@@ -75,7 +75,7 @@
 
                         a {
                             font: inherit;
-                            color: @gg-blue;
+                            color: @color-primary;
                             background: none;
                             padding: 0.3em 0.5em;
                             border-radius: @default-border-radius;
@@ -83,7 +83,7 @@
                             box-shadow: none;
 
                             &:hover {
-                                border-color: @gg-border-grey;
+                                border-color: @color-border;
                             }
 
                             p {
@@ -111,8 +111,8 @@
                             font: inherit;
 
                             a {
-                                border-color: @gg-blue;
-                                background-color: @gg-blue;
+                                border-color: @color-primary;
+                                background-color: @color-primary;
                                 color: @white;
                             }
                         }
@@ -148,7 +148,7 @@
 
                     background: none;
                     box-shadow: none;
-                    border: 3px solid @gg-border-grey;
+                    border: 3px solid @color-border;
                     overflow: hidden;
 
                     &.prev {
@@ -168,7 +168,7 @@
                         background-position: center 12px;
 
                         &.disabled {
-                            background-color: @gg-border-grey;
+                            background-color: @color-border;
                         }
                     }
                 }
@@ -192,11 +192,11 @@
                         min-width: 0;
 
                         &:first-child a {
-                            border-left: 3px solid @gg-border-grey;
+                            border-left: 3px solid @color-border;
                         }
 
                         &:last-child a {
-                            border-right: 3px solid @gg-border-grey;
+                            border-right: 3px solid @color-border;
                         }
 
                         a {
@@ -207,70 +207,70 @@
                             border: 0 none;
                             box-shadow: none;
                             color: @white;
-                            border-top: 3px solid @gg-border-grey;
-                            border-bottom: 3px solid @gg-border-grey;
+                            border-top: 3px solid @color-border;
+                            border-bottom: 3px solid @color-border;
 
                             @media (max-width: @screen-sm-max) {
                                 display: none;
                             }
 
                             &.active {
-                                border-color: @gg-blue;
-                                color: @gg-blue;
+                                border-color: @color-primary;
+                                color: @color-primary;
 
                                 @media (max-width: @screen-sm-max) {
                                     display: block;
-                                    border: 3px solid @gg-blue;
+                                    border: 3px solid @color-primary;
                                 }
 
                                 &.progress-none {
-                                    border-color: @gg-blue;
-                                    color: @gg-blue;
+                                    border-color: @color-primary;
+                                    color: @color-primary;
                                 }
 
                                 &.progress-some {
-                                    border-color: @gg-orange;
-                                    color: @gg-orange;
+                                    border-color: @color-warning;
+                                    color: @color-warning;
                                 }
 
                                 &.progress-in_progress {
-                                    border-color: @gg-orange;
-                                    color: @gg-orange;
+                                    border-color: @color-warning;
+                                    color: @color-warning;
                                 }
 
                                 &.progress-done {
-                                    border-color: @gg-emerald;
-                                    color: @gg-emerald;
+                                    border-color: @color-success;
+                                    color: @color-success;
                                 }
                             }
 
                             &.inactive, &.visited {
                                 &.progress-none, &.progress-0 {
-                                    background-color: @gg-border-grey;
+                                    background-color: @color-border;
 
                                     &:hover {
                                         background: @white;
-                                        color: @gg-border-grey;
+                                        color: @color-border;
                                     }
                                 }
 
                                 &.progress-some, &.progress-in_progress {
-                                    background-color: @gg-orange;
-                                    border-color: @gg-orange;
+                                    background-color: @color-warning;
+                                    border-color: @color-warning;
 
                                     &:hover {
                                         background-color: @white;
-                                        color: @gg-orange;
+                                        color: @color-warning;
                                     }
                                 }
 
                                 &.progress-done {
-                                    background-color: @gg-emerald;
-                                    border-color: @gg-emerald;
+                                    background-color: @color-success;
+                                    border-color: @color-success;
 
                                     &:hover {
                                         background-color: @white;
-                                        color: @gg-emerald;
+                                        color: @color-success;
                                     }
                                 }
                             }
@@ -321,7 +321,7 @@
 
                     background: none;
                     box-shadow: none;
-                    border: 3px solid @gg-border-grey;
+                    border: 3px solid @color-border;
                     overflow: hidden;
 
                     &.prev {
@@ -336,7 +336,7 @@
                         background-position: center 0.85em;
 
                         &.disabled {
-                            background-color: @gg-border-grey;
+                            background-color: @color-border;
                         }
                     }
                 }

--- a/static/less/pages/course/forum.less
+++ b/static/less/pages/course/forum.less
@@ -13,7 +13,7 @@
         > .new-post-form {
             .square(auto);
 
-            border: 1px solid @gg-border-grey;
+            border: 1px solid @color-border;
             border-radius: @default-border-radius;
             margin: 0;
             background: none;
@@ -91,13 +91,13 @@
                 }
 
                 input[type=submit] {
-                    .ionisx-btn(@white, @gg-emerald);
+                    .ionisx-btn(@white, @color-success);
 
                     font-size: 0.9em;
                 }
 
                 .new-post-cancel {
-                    .ionisx-btn(@black, @gg-grey);
+                    .ionisx-btn(@black, @color-background);
 
                     font-size: 0.9em;
                     margin-left: 1em;
@@ -117,7 +117,7 @@
         overflow: visible;
 
         > .sidebar {
-            border: 1px solid @gg-border-grey;
+            border: 1px solid @color-border;
             border-radius: @default-border-radius;
             box-shadow: none;
             display: block;
@@ -153,7 +153,7 @@
                             background: none;
                             box-shadow: none;
                             color: @black;
-                            border-bottom: 1px solid @gg-border-grey;
+                            border-bottom: 1px solid @color-border;
                             margin: 0;
                             padding: 0 0.4em 0 1.9em;
 
@@ -163,7 +163,7 @@
                                 position: absolute;
                                 left: 0.5em;
                                 top: 0.75em;
-                                color: @gg-blue;
+                                color: @color-primary;
                             }
 
                             span {
@@ -202,7 +202,7 @@
                             }
 
                             &.active {
-                                background: @gg-blue;
+                                background: @color-primary;
                                 color: @white;
 
                                 &:before {
@@ -240,7 +240,7 @@
         }
 
         > .discussion-column {
-            border: 1px solid @gg-border-grey;
+            border: 1px solid @color-border;
             border-radius: @default-border-radius;
             box-shadow: none;
             background: none;
@@ -263,7 +263,7 @@
                     }
 
                     .home-header {
-                        border-bottom: 1px solid @gg-border-grey;
+                        border-bottom: 1px solid @color-border;
                         margin: 0 0 1em 0;
 
                         .label {
@@ -274,7 +274,7 @@
                             font: inherit;
                             font-size: @font-size-h2;
                             font-weight: @headings-font-weight;
-                            color: @gg-blue;
+                            color: @color-primary;
                             border: 0 none;
                             padding: 0;
                             margin: 0 0 0.5em 0;
@@ -311,14 +311,14 @@
                 input[type=submit],
                 .discussion-submit-post,
                 .discussion-submit-comment {
-                    .ionisx-btn(@white, @gg-emerald);
+                    .ionisx-btn(@white, @color-success);
 
                     font-size: 0.9em;
                     margin-top: 1em;
                 }
 
                 .post-cancel {
-                    .ionisx-btn(@black, @gg-grey);
+                    .ionisx-btn(@black, @color-background);
 
                     font-size: 0.9em;
                     margin-left: 1em;
@@ -328,21 +328,21 @@
                 .moderator-actions {
                     a {
                         &.action-edit {
-                            .ionisx-btn(@white, @gg-alt-blue);
+                            .ionisx-btn(@white, @color-secondary);
 
                             font-size: 0.8em;
                             padding: 0.2em 1.2em;
                         }
 
                         &.action-delete {
-                            .ionisx-btn(@white, @gg-pomegranate);
+                            .ionisx-btn(@white, @color-error);
 
                             font-size: 0.8em;
                             padding: 0.2em 1.2em;
                         }
 
                         &.action-openclose {
-                            .ionisx-btn(@black, @gg-border-grey);
+                            .ionisx-btn(@black, @color-border);
 
                             font-size: 0.8em;
                             padding: 0.2em 1.2em;
@@ -359,7 +359,7 @@
                 .discussion-post {
                     padding: 30px;
                     box-shadow: none;
-                    border-bottom: 1px solid @gg-border-grey;
+                    border-bottom: 1px solid @color-border;
 
                     @media (max-width: @screen-xs-max) {
                         padding: 10px;
@@ -369,7 +369,7 @@
                         font: inherit;
                         font-size: @font-size-h2;
                         font-weight: @headings-font-weight;
-                        color: @gg-blue;
+                        color: @color-primary;
                         border: 0 none;
                         padding: 0;
                         margin: 0 0 0.5em 0;
@@ -380,7 +380,7 @@
                             font: inherit;
                             font-size: @font-size-h2;
                             font-weight: @headings-font-weight;
-                            color: @gg-blue;
+                            color: @color-primary;
                             border: 0 none;
                             padding: 0;
                             margin: 0 0 0.5em 0;
@@ -409,14 +409,14 @@
 
                                 &:hover {
                                     text-decoration: none;
-                                    color: fadeout(@gg-blue, 10%);
+                                    color: fadeout(@color-primary, 10%);
                                 }
                             }
 
                             .timeago {
                                 font: inherit;
                                 font-size: 0.8em;
-                                color: @gg-disabled-grey;
+                                color: @color-disabled;
                             }
                         }
                     }
@@ -425,7 +425,7 @@
                 .response-count {
                     margin: 0;
                     padding: 20px 30px;
-                    border-bottom: 1px solid @gg-border-grey;
+                    border-bottom: 1px solid @color-border;
 
                     @media (max-width: @screen-xs-max) {
                         padding: 10px;
@@ -441,7 +441,7 @@
                     }
 
                     button {
-                        .ionisx-btn(@white, @gg-alt-blue);
+                        .ionisx-btn(@white, @color-secondary);
 
                         width: 100%;
                     }
@@ -461,7 +461,7 @@
                         display: block;
                         margin: 0 0 1em 0;
                         box-shadow: none;
-                        border: 1px solid @gg-border-grey;
+                        border: 1px solid @color-border;
                         border-radius: @default-border-radius;
                         transition: none;
                         overflow: hidden;
@@ -486,7 +486,7 @@
                                     text-transform: none;
                                     position: static;
                                     background: none;
-                                    background-color: @gg-orange;
+                                    background-color: @color-warning;
                                     color: @white;
                                     margin: 0 0.6em 0 0;
                                     padding: 2px 8px;
@@ -507,7 +507,7 @@
 
                                     &:hover {
                                         text-decoration: none;
-                                        color: fadeout(@gg-blue, 10%);
+                                        color: fadeout(@color-primary, 10%);
                                     }
                                 }
 
@@ -515,18 +515,18 @@
                                     display: inline;
                                     font: inherit;
                                     font-size: 0.8em;
-                                    color: @gg-disabled-grey;
+                                    color: @color-disabled;
                                 }
                             }
                         }
                         .comments {
                             li {
-                                background-color: @gg-grey;
+                                background-color: @color-background;
                                 padding: 0.6em 1em;
 
                                 .posted-details {
                                     font: inherit;
-                                    color: @gg-disabled-grey;
+                                    color: @color-disabled;
                                     font-size: 0.8em;
 
                                     .timeago {
@@ -537,7 +537,7 @@
                                     .staff-label {
                                         font: inherit;
                                         font-size: 0.8em;
-                                        background-color: @gg-orange;
+                                        background-color: @color-warning;
                                         color: @white;
                                         margin: 0 0 0 5px;
                                     }
@@ -551,9 +551,9 @@
 
                                 .comment-form {
                                     background: none;
-                                    background-color: @gg-grey;
+                                    background-color: @color-background;
                                     padding: 1em;
-                                    border-top: 1px solid @gg-border-grey;
+                                    border-top: 1px solid @color-border;
                                 }
                             }
                         }
@@ -564,8 +564,8 @@
                     padding: 20px 30px;
                     box-shadow: none;
                     background: none;
-                    border-top: 1px solid @gg-border-grey;
-                    border-bottom: 1px solid @gg-border-grey;
+                    border-top: 1px solid @color-border;
+                    border-bottom: 1px solid @color-border;
 
                     @media (max-width: @screen-xs-max) {
                         padding: 10px;

--- a/static/less/pages/course/info.less
+++ b/static/less/pages/course/info.less
@@ -5,7 +5,7 @@
     background: none;
     box-shadow: none;
     border-radius: @default-border-radius;
-    border: 1px solid @gg-border-grey;
+    border: 1px solid @color-border;
     background-color: @white;
     margin: 0;
 
@@ -21,7 +21,7 @@
             font: inherit;
             font-size: @font-size-h2;
             font-weight: @headings-font-weight;
-            color: @gg-blue;
+            color: @color-primary;
             border: 0 none;
             padding: 0;
             margin: 0 0 1.5em 0;
@@ -34,11 +34,11 @@
             > article {
                 margin: 0 0 1em 0;
                 padding: 10px;
-                border: 1px solid @gg-border-grey;
+                border: 1px solid @color-border;
                 border-radius: @default-border-radius;
 
                 &:nth-child(odd) {
-                    background-color: @gg-grey;
+                    background-color: @color-background;
                 }
 
                 > h2 {
@@ -48,13 +48,13 @@
                     background: none;
                     margin: 0 0 1em 0;
                     padding: 0;
-                    border-bottom: 1px solid @gg-border-grey;
+                    border-bottom: 1px solid @color-border;
 
                     &:before {
                         content: '\f073';
                         font-family: 'FontAwesome';
                         font-weight: 500;
-                        color: @gg-emerald;
+                        color: @color-success;
                         margin: 0 0.4em 0 0;
                     }
                 }

--- a/static/less/pages/course/instructor.less
+++ b/static/less/pages/course/instructor.less
@@ -13,7 +13,7 @@
             font: inherit;
             font-size: @font-size-h2;
             font-weight: @headings-font-weight;
-            color: @gg-blue;
+            color: @color-primary;
             border: 0 none;
             padding: 0;
             margin: 0 0 1.5em 0;
@@ -33,7 +33,7 @@
             color: inherit;
             padding: 0;
             margin: 0;
-            border: 1px solid @gg-border-grey;
+            border: 1px solid @color-border;
             border-radius: @default-border-radius;
             overflow: hidden;
 
@@ -50,11 +50,11 @@
 
                     &:hover {
                         text-decoration: none;
-                        background-color: @gg-grey;
+                        background-color: @color-background;
                     }
 
                     &.active-section {
-                        background-color: @gg-alt-blue;
+                        background-color: @color-secondary;
                         color: @white;
                     }
                 }
@@ -70,7 +70,7 @@
         }
 
         input[type=button] {
-            .ionisx-btn(@white, @gg-alt-blue);
+            .ionisx-btn(@white, @color-secondary);
 
             font-size: 0.9em;
         }

--- a/static/less/pages/course/main.less
+++ b/static/less/pages/course/main.less
@@ -57,12 +57,12 @@
                         box-shadow: none;
                         text-shadow: none;
                         background: none;
-                        background-color: @gg-blue;
+                        background-color: @color-primary;
                         color: @white;
                     }
 
                     &.new-post-btn {
-                        .ionisx-btn(@white, @gg-alt-blue);
+                        .ionisx-btn(@white, @color-secondary);
 
                         font-size: 0.9em;
 
@@ -101,7 +101,7 @@
         box-shadow: none;
         background: none;
         background-color: @white;
-        border: 1px solid @gg-border-grey;
+        border: 1px solid @color-border;
         border-radius: @default-border-radius;
         overflow: hidden;
 

--- a/static/less/pages/course/progression.less
+++ b/static/less/pages/course/progression.less
@@ -16,7 +16,7 @@
                 font: inherit;
                 font-size: @font-size-h2;
                 font-weight: @headings-font-weight;
-                color: @gg-blue;
+                color: @color-primary;
                 border: 0 none;
                 padding: 0;
                 margin: 0;

--- a/static/less/pages/course/xblock.less
+++ b/static/less/pages/course/xblock.less
@@ -6,12 +6,12 @@
                 margin: 0 0 2em 0;
                 padding: 0 0 2em 0;
                 position: relative;
-                border-bottom: 1px solid @gg-border-grey;
+                border-bottom: 1px solid @color-border;
 
                 &:after {
                     content: '\f103';
                     font-family: 'FontAwesome';
-                    color: @gg-border-grey;
+                    color: @color-border;
                     display: block;
                     margin: 2em 0 0 0;
                     text-align: center;
@@ -62,7 +62,7 @@
 
     &.xmodule_DiscussionModule {
         .discussion-module {
-            border: 1px solid @gg-border-grey;
+            border: 1px solid @color-border;
             border-radius: @default-border-radius;
 
             .discussion {
@@ -90,7 +90,7 @@
                         > .new-post-form {
                             .square(auto);
 
-                            border: 1px solid @gg-border-grey;
+                            border: 1px solid @color-border;
                             border-radius: @default-border-radius;
                             margin: 0;
                             background: none;
@@ -126,13 +126,13 @@
                             }
 
                             input[type=submit] {
-                                .ionisx-btn(@white, @gg-emerald);
+                                .ionisx-btn(@white, @color-success);
 
                                 font-size: 0.9em;
                             }
 
                             .new-post-cancel {
-                                .ionisx-btn(@black, @gg-grey);
+                                .ionisx-btn(@black, @color-background);
 
                                 font-size: 0.9em;
                                 margin-left: 1em;
@@ -144,7 +144,7 @@
         }
 
         .new-post-btn {
-            .ionisx-btn(@white, @gg-alt-blue);
+            .ionisx-btn(@white, @color-secondary);
 
             font-size: 0.9em;
 
@@ -189,7 +189,7 @@
         }
 
         button, input[type=button] {
-            .ionisx-btn(@white, @gg-alt-blue);
+            .ionisx-btn(@white, @color-secondary);
 
             font-size: 0.9em;
             display: inline;
@@ -202,7 +202,7 @@
 
         .submission_feedback {
             font: inherit;
-            color: @gg-disabled-grey;
+            color: @color-disabled;
         }
 
         .action {
@@ -219,7 +219,7 @@
 
     .taggedtext {
         button, input[type=button] {
-            .ionisx-btn(@white, @gg-alt-blue);
+            .ionisx-btn(@white, @color-secondary);
 
             font-size: 0.9em;
             display: inline;
@@ -232,7 +232,7 @@
 
         .submission_feedback {
             font: inherit;
-            color: @gg-disabled-grey;
+            color: @color-disabled;
         }
     }
 }

--- a/static/less/pages/courses.less
+++ b/static/less/pages/courses.less
@@ -39,7 +39,7 @@
 
                 &:hover {
                     box-shadow: none;
-                    border-color: @gg-blue;
+                    border-color: @color-primary;
                 }
 
                 .inner-wrapper {
@@ -47,7 +47,7 @@
 
                     .course-preview {
                         box-shadow: none;
-                        border-bottom: 1px solid @gg-border-grey;
+                        border-bottom: 1px solid @color-border;
                         background: none;
                         background-color: fadeout(@white, 10%);
 

--- a/static/less/pages/dashboard.less
+++ b/static/less/pages/dashboard.less
@@ -50,7 +50,7 @@
                             .text-right();
 
                             font: inherit;
-                            color: @gg-blue;
+                            color: @color-primary;
                             margin: 0 10px 0 0;
                             float: none;
                             display: inline-block;
@@ -111,7 +111,7 @@
             }
 
             > a {
-                .ionisx-btn(@white, @gg-alt-blue);
+                .ionisx-btn(@white, @color-secondary);
 
                 font-size: 0.9em;
             }
@@ -124,7 +124,7 @@
                 margin: 0 0 30px 0;
                 transition: all .1s ease-in;
                 background-color: @white;
-                border: 1px solid @gg-border-grey;
+                border: 1px solid @color-border;
                 border-radius: @default-border-radius;
                 padding: 20px;
 
@@ -147,7 +147,7 @@
                 }
 
                 &:hover {
-                    border-color: @gg-blue;
+                    border-color: @color-primary;
                 }
 
                 &:last-child {
@@ -157,11 +157,11 @@
                 .cover {
                     .size(200px, auto);
 
-                    background-color: @gg-grey;
+                    background-color: @color-background;
                     transition: none;
                     max-height: none;
                     text-align: center;
-                    border: 1px solid @gg-grey;
+                    border: 1px solid @color-background;
                     border-radius: @default-border-radius;
                     float: left;
                     display: block;
@@ -191,7 +191,7 @@
                         font-size: 0.9em;
 
                         &.cover-university {
-                            color: @gg-blue;
+                            color: @color-primary;
                             font-weight: @headings-font-weight;
                             font-size: 0.9em;
                         }
@@ -199,15 +199,15 @@
                         &.cover-course-status {
 
                             &.course-soon {
-                                color: @gg-disabled-grey;
+                                color: @color-disabled;
                             }
 
                             &.course-open {
-                                color: @gg-emerald;
+                                color: @color-success;
                             }
 
                             &.course-ended {
-                                color: @gg-pomegranate;
+                                color: @color-error;
                             }
                         }
                     }
@@ -290,7 +290,7 @@
                     }
 
                     .enter-course {
-                        .ionisx-btn(@white, @gg-alt-blue);
+                        .ionisx-btn(@white, @color-secondary);
                         .size(100%, auto);
 
                         font-size: 0.9em;
@@ -329,7 +329,7 @@
                             &:before {
                                 font-family: 'FontAwesome';
                                 font-size: 1.2em;
-                                color: @gg-pomegranate;
+                                color: @color-error;
                                 content: '\f00d';
                             }
                         }

--- a/static/less/pages/homepage.less
+++ b/static/less/pages/homepage.less
@@ -39,7 +39,7 @@
 
                 &:hover {
                     box-shadow: none;
-                    border-color: @gg-blue;
+                    border-color: @color-primary;
                 }
 
                 .inner-wrapper {
@@ -47,7 +47,7 @@
 
                     .course-preview {
                         box-shadow: none;
-                        border-bottom: 1px solid @gg-border-grey;
+                        border-bottom: 1px solid @color-border;
                         background: none;
                         background-color: fadeout(@white, 10%);
 

--- a/static/less/pages/login.less
+++ b/static/less/pages/login.less
@@ -19,7 +19,7 @@
 
         a {
             font: inherit;
-            color: @gg-blue;
+            color: @color-primary;
         }
 
         form {
@@ -66,7 +66,7 @@
 
             .form-actions {
                 button[type=submit] {
-                    .ionisx-btn(@white, @gg-alt-blue);
+                    .ionisx-btn(@white, @color-secondary);
 
                     @media (min-width: @screen-md-min) {
                         .square(auto);
@@ -99,7 +99,7 @@
 
         a {
             font: inherit;
-            color: @gg-blue;
+            color: @color-primary;
         }
     }
 }

--- a/static/less/pages/main.less
+++ b/static/less/pages/main.less
@@ -42,7 +42,7 @@ body,
                     display: block;
                     font: inherit;
                     font-size: @font-size-h1;
-                    color: @gg-blue;
+                    color: @color-primary;
                     text-transform: none;
                 }
 

--- a/static/less/pages/password-reset.less
+++ b/static/less/pages/password-reset.less
@@ -24,7 +24,7 @@
 
         a {
             font: inherit;
-            color: @gg-blue;
+            color: @color-primary;
         }
 
         form {
@@ -60,7 +60,7 @@
 
             .form-actions {
                 button[type=submit] {
-                    .ionisx-btn(@white, @gg-emerald);
+                    .ionisx-btn(@white, @color-success);
 
                     @media (min-width: @screen-md-min) {
                         .square(auto);
@@ -93,7 +93,7 @@
 
         a {
             font: inherit;
-            color: @gg-blue;
+            color: @color-primary;
         }
     }
 }

--- a/static/less/pages/register.less
+++ b/static/less/pages/register.less
@@ -19,7 +19,7 @@
 
         a {
             font: inherit;
-            color: @gg-blue;
+            color: @color-primary;
         }
 
         form {
@@ -58,7 +58,7 @@
             }
 
             .field.is-focused label {
-                color: @gg-blue;
+                color: @color-primary;
             }
 
             input[type=text],
@@ -79,7 +79,7 @@
 
             .form-actions {
                 button[type=submit] {
-                    .ionisx-btn(@white, @gg-alt-blue);
+                    .ionisx-btn(@white, @color-secondary);
 
                     @media (min-width: @screen-md-min) {
                         .square(auto);
@@ -112,7 +112,7 @@
 
         a {
             font: inherit;
-            color: @gg-blue;
+            color: @color-primary;
         }
     }
 }

--- a/static/less/reset.less
+++ b/static/less/reset.less
@@ -14,7 +14,7 @@ h1 {
 }
 
 h2 {
-    color: @gg-blue;
+    color: @color-primary;
     text-transform: none;
 }
 
@@ -23,7 +23,7 @@ h3 {
 }
 
 h4 {
-    color: @gg-blue;
+    color: @color-primary;
     font-weight: 500;
 }
 
@@ -48,7 +48,7 @@ ul {
 a, a:link, a:visited,
 p a, p a:link, p a:visited {
     font: inherit;
-    color: @gg-blue;
+    color: @color-primary;
     outline: none;
 
     &:hover, &:focus, &:active {
@@ -76,22 +76,22 @@ textarea {
 
 ::-webkit-input-placeholder {
     font: inherit;
-    color: @gg-disabled-grey;
+    color: @color-disabled;
 }
 
 :-moz-placeholder {
     font: inherit;
-    color: @gg-disabled-grey;
+    color: @color-disabled;
 }
 
 ::-moz-placeholder {
     font: inherit;
-    color: @gg-disabled-grey;
+    color: @color-disabled;
 }
 
 :-ms-input-placeholder {
     font: inherit;
-    color: @gg-disabled-grey;
+    color: @color-disabled;
 }
 
 .row {

--- a/static/less/variables.less
+++ b/static/less/variables.less
@@ -5,19 +5,19 @@
 @white: #fff;
 @black: lighten(#000, 8%);
 
-@gg-blue: #3ea5ce;
-@gg-grey: #eef0f1;
-@gg-alt-blue: #0f70b7;
+@color-primary: #3ea5ce;
+@color-secondary: #0f70b7;
+@color-background: #eef0f1;
 
-@gg-pomegranate: #c0392b;
-@gg-emerald: #2ecc71;
-@gg-orange: #f39c12;
+@color-error: #c0392b;
+@color-success: #2ecc71;
+@color-warning: #f39c12;
 
-@gg-disabled-grey: #bdc3c7;
-@gg-border-grey: #ddd;
+@color-disabled: #bdc3c7;
+@color-border: #ddd;
 
 // Misc
-@hr-border: @gg-border-grey;
+@hr-border: @color-border;
 
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Remove color names from the variables names so they can be any colors.

@Shedna what do you think?

I thought about using bootstrap variable names (brand-primary, brand-warning, etc.) but they don’t have a variable for everything.

So it’s probably better to have our own configuration, then map everything to bootstrap.
