### PR TITLE
Bump grunt-contrib-imagemin dependency to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-contrib-jshint": "0.11.2",
     "grunt-contrib-cssmin": "0.12.2",
-    "grunt-contrib-imagemin": "0.9.4",
+    "grunt-contrib-imagemin": "1.0.0",
     "grunt-contrib-copy": "0.8.0",
     "grunt-autoprefixer": "3.0.0",
     "grunt-bless": "0.2.0",


### PR DESCRIPTION
See issue gruntjs/grunt-contrib-imagemin#208 for explanation of why
the prior version would cause a fatal "Cannot read property 'contents'
of undefined" error when processing a non-empty list of images with
imagemin.

Fixes IONISx/edx-theme#54.
